### PR TITLE
feat: get nearest location and pin at top

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -127,49 +127,58 @@ const Home = () => {
 	}, [_institutions, query, selectedCategories, selectedState, offset, limit]);
 
 	const displayedInstitutions = filteredInstitutions.slice(0, offset + limit);
-  const isFiltered = useMemo(()=>query !== "" || selectedCategories.length > 0 || selectedState !== "",[query, selectedCategories, selectedState])
-  const filteredInstitutionsContainsClosest = useMemo(()=>filteredInstitutions.findIndex(i=>i.id===closestInstitution?.id) !== -1, [filteredInstitutions, closestInstitution])
+	const isFiltered = useMemo(
+		() => query !== "" || selectedCategories.length > 0 || selectedState !== "",
+		[query, selectedCategories, selectedState],
+	);
+	const filteredInstitutionsContainsClosest = useMemo(
+		() =>
+			filteredInstitutions.findIndex((i) => i.id === closestInstitution?.id) !==
+			-1,
+		[filteredInstitutions, closestInstitution],
+	);
 
 	useEffect(() => {
 		getLocation();
 	}, []);
 
 	async function getLocation() {
-			navigator.geolocation.getCurrentPosition((p) => {
-				setCurrentUserCoordinate({
-					latitude: p.coords.latitude,
-					longitude: p.coords.longitude,
-				});
+		navigator.geolocation.getCurrentPosition((p) => {
+			setCurrentUserCoordinate({
+				latitude: p.coords.latitude,
+				longitude: p.coords.longitude,
 			});
+		});
 	}
 
 	useEffect(() => {
-    if (isFiltered || !currentUserCoordinate || closestInstitution) return;
+		if (isFiltered || !currentUserCoordinate || closestInstitution) return;
 
-    let listOfCoords: { latitude: number; longitude: number; id: number }[] = [];
+		let listOfCoords: { latitude: number; longitude: number; id: number }[] =
+			[];
 
-    filteredInstitutions.forEach((i) => {
-      if (i.coords && i.coords.length === 2) {
-        listOfCoords.push({
-          latitude: i.coords[0],
-          longitude: i.coords[1],
-          ...i,
-        });
-      }
-    });
+		filteredInstitutions.forEach((i) => {
+			if (i.coords && i.coords.length === 2) {
+				listOfCoords.push({
+					latitude: i.coords[0],
+					longitude: i.coords[1],
+					...i,
+				});
+			}
+		});
 
-    const closestCoordinate = findNearest(
-      currentUserCoordinate,
-      listOfCoords,
-    );
-    const distanceToCurrentUserInMeter = getDistance(
-      currentUserCoordinate,
-      closestCoordinate,
-    );
+		const closestCoordinate = findNearest(currentUserCoordinate, listOfCoords);
+		const distanceToCurrentUserInMeter = getDistance(
+			currentUserCoordinate,
+			closestCoordinate,
+		);
 
-    const c = {...closestCoordinate, distanceToCurrentUserInMeter} as unknown as Institution & { distanceToCurrentUserInMeter: number }
+		const c = {
+			...closestCoordinate,
+			distanceToCurrentUserInMeter,
+		} as unknown as Institution & { distanceToCurrentUserInMeter: number };
 
-    setClosestInstitution(c);
+		setClosestInstitution(c);
 	}, [currentUserCoordinate, filteredInstitutions]);
 
 	return (
@@ -241,29 +250,33 @@ const Home = () => {
 				</div>
 			) : (
 				<div className="grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-					{(closestInstitution && filteredInstitutionsContainsClosest) && (
+					{closestInstitution && filteredInstitutionsContainsClosest && (
 						<InstitutionCard
 							key={closestInstitution.id}
 							{...closestInstitution}
 							ref={
-								displayedInstitutions.length === 1
-									? lastPostElementRef
-									: null
+								displayedInstitutions.length === 1 ? lastPostElementRef : null
 							}
-              isClosest
+							isClosest
 						/>
 					)}
-					{displayedInstitutions.filter((i)=>(filteredInstitutionsContainsClosest && closestInstitution) ? i.id !== closestInstitution.id : true).map((institution, i) => (
-						<InstitutionCard
-							key={institution.id}
-							{...institution}
-							ref={
-								displayedInstitutions.length === i + 1
-									? lastPostElementRef
-									: null
-							}
-						/>
-					))}
+					{displayedInstitutions
+						.filter((i) =>
+							filteredInstitutionsContainsClosest && closestInstitution
+								? i.id !== closestInstitution.id
+								: true,
+						)
+						.map((institution, i) => (
+							<InstitutionCard
+								key={institution.id}
+								{...institution}
+								ref={
+									displayedInstitutions.length === i + 1
+										? lastPostElementRef
+										: null
+								}
+							/>
+						))}
 				</div>
 			)}
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { debounce } from "lodash-es";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { findNearest, getDistance } from "geolib";
-import { GeolibInputCoordinates } from "geolib/es/types";
+import type { GeolibInputCoordinates } from "geolib/es/types";
 
 import CollapsibleCustomMap from "@/components/custom-map";
 import RawakFooter from "@/components/rawak-footer";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -128,7 +128,7 @@ const Home = () => {
 
 	const displayedInstitutions = filteredInstitutions.slice(0, offset + limit);
   const isFiltered = useMemo(()=>query !== "" || selectedCategories.length > 0 || selectedState !== "",[query, selectedCategories, selectedState])
-  const displayedInstitutionsContainsClosest = useMemo(()=>displayedInstitutions.findIndex(i=>i.id===closestInstitution?.id) !== -1, [displayedInstitutions, closestInstitution])
+  const filteredInstitutionsContainsClosest = useMemo(()=>filteredInstitutions.findIndex(i=>i.id===closestInstitution?.id) !== -1, [filteredInstitutions, closestInstitution])
 
 	useEffect(() => {
 		getLocation();
@@ -146,33 +146,32 @@ const Home = () => {
 	}
 
 	useEffect(() => {
-    if (isFiltered) return;
+    if (isFiltered || !currentUserCoordinate || closestInstitution) return;
 
-		let listOfCoords: { latitude: number; longitude: number; id: number }[] = [];
-		if (currentUserCoordinate) {
-			filteredInstitutions.forEach((i) => {
-				if (i.coords && i.coords.length === 2) {
-					listOfCoords.push({
-						latitude: i.coords[0],
-						longitude: i.coords[1],
-						...i,
-					});
-				}
-			});
+    let listOfCoords: { latitude: number; longitude: number; id: number }[] = [];
 
-			const closestCoordinate = findNearest(
-				currentUserCoordinate,
-				listOfCoords,
-			);
-			const distanceToCurrentUserInKM = getDistance(
-				currentUserCoordinate,
-				closestCoordinate,
-			);
+    filteredInstitutions.forEach((i) => {
+      if (i.coords && i.coords.length === 2) {
+        listOfCoords.push({
+          latitude: i.coords[0],
+          longitude: i.coords[1],
+          ...i,
+        });
+      }
+    });
 
-      const c = {...closestCoordinate, distanceToCurrentUserInKM} as unknown as Institution & { distanceToCurrentUserInKM: number }
+    const closestCoordinate = findNearest(
+      currentUserCoordinate,
+      listOfCoords,
+    );
+    const distanceToCurrentUserInKM = getDistance(
+      currentUserCoordinate,
+      closestCoordinate,
+    );
 
-      setClosestInstitution(c);
-		}
+    const c = {...closestCoordinate, distanceToCurrentUserInKM} as unknown as Institution & { distanceToCurrentUserInKM: number }
+
+    setClosestInstitution(c);
 	}, [currentUserCoordinate, filteredInstitutions]);
 
 	return (
@@ -244,7 +243,7 @@ const Home = () => {
 				</div>
 			) : (
 				<div className="grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-					{(closestInstitution && displayedInstitutionsContainsClosest) && (
+					{(closestInstitution && filteredInstitutionsContainsClosest) && (
 						<InstitutionCard
 							key={closestInstitution.id}
 							{...closestInstitution}
@@ -256,7 +255,7 @@ const Home = () => {
               isClosest
 						/>
 					)}
-					{displayedInstitutions.filter((i)=>(displayedInstitutionsContainsClosest && closestInstitution) ? i.id !== closestInstitution.id : true).map((institution, i) => (
+					{displayedInstitutions.filter((i)=>(filteredInstitutionsContainsClosest && closestInstitution) ? i.id !== closestInstitution.id : true).map((institution, i) => (
 						<InstitutionCard
 							key={institution.id}
 							{...institution}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,7 +36,7 @@ const Home = () => {
 	const [currentUserCoordinate, setCurrentUserCoordinate] =
 		useState<GeolibInputCoordinates | null>(null);
 	const [closestInstitution, setClosestInstitution] = useState<
-		(Institution & { distanceToCurrentUserInKM: number }) | null
+		(Institution & { distanceToCurrentUserInMeter: number }) | null
 	>(null);
 
 	// Map
@@ -135,14 +135,12 @@ const Home = () => {
 	}, []);
 
 	async function getLocation() {
-		if (navigator.geolocation) {
 			navigator.geolocation.getCurrentPosition((p) => {
 				setCurrentUserCoordinate({
 					latitude: p.coords.latitude,
 					longitude: p.coords.longitude,
 				});
 			});
-		}
 	}
 
 	useEffect(() => {
@@ -164,12 +162,12 @@ const Home = () => {
       currentUserCoordinate,
       listOfCoords,
     );
-    const distanceToCurrentUserInKM = getDistance(
+    const distanceToCurrentUserInMeter = getDistance(
       currentUserCoordinate,
       closestCoordinate,
     );
 
-    const c = {...closestCoordinate, distanceToCurrentUserInKM} as unknown as Institution & { distanceToCurrentUserInKM: number }
+    const c = {...closestCoordinate, distanceToCurrentUserInMeter} as unknown as Institution & { distanceToCurrentUserInMeter: number }
 
     setClosestInstitution(c);
 	}, [currentUserCoordinate, filteredInstitutions]);

--- a/components/ui/institution-card.tsx
+++ b/components/ui/institution-card.tsx
@@ -18,7 +18,7 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useOutsideClick } from "@/hooks/use-outside-click";
-import { slugify } from "@/lib/utils";
+import { cn, slugify } from "@/lib/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import html2canvas from "html2canvas";
 import { DownloadIcon, Eye, Share2 } from "lucide-react";
@@ -51,7 +51,7 @@ const capitalizeWords = (str: string): string => {
 	});
 };
 
-const InstitutionCard = forwardRef<HTMLDivElement, Institution>(
+const InstitutionCard = forwardRef<HTMLDivElement, Institution & {isClosest?: boolean; distanceToCurrentUserInKM?: number}>(
 	(
 		{
 			id,
@@ -64,6 +64,8 @@ const InstitutionCard = forwardRef<HTMLDivElement, Institution>(
 			supportedPayment,
 			category,
 			coords,
+      isClosest,
+      distanceToCurrentUserInKM,
 		},
 		ref,
 	) => {
@@ -271,10 +273,15 @@ const InstitutionCard = forwardRef<HTMLDivElement, Institution>(
 				<TooltipProvider>
 					<motion.div ref={ref} layoutId={`card-${name}-${id}`}>
 						<Card
-							className="group border-0 shadow-lg dark:shadow-muted/50 cursor-pointer hover:shadow-xl transition-shadow duration-200 ease-in-out hover:bg-gray-100 dark:hover:bg-zinc-900"
+							className={cn("relative group border-4 border-transparent shadow-lg dark:shadow-muted/50 cursor-pointer hover:shadow-xl transition-shadow duration-200 ease-in-out hover:bg-gray-100 dark:hover:bg-zinc-900", isClosest && "border-yellow-500 dark:border-yellow-400")}
 							onClick={() => navigateToItem(category, slugify(name))}
 						>
 							<CardContent className="flex flex-col items-center gap-2 p-4 h-full">
+                {isClosest && (
+                  <div className="absolute top-2 left-2 bg-yellow-500 dark:bg-yellow-400 text-black p-1 px-2 rounded-full text-xs font-semibold">
+                    Closest to you{distanceToCurrentUserInKM && distanceToCurrentUserInKM > 1000 ? ` • ${(distanceToCurrentUserInKM / 1000).toFixed(2)} KM` : ` • ${distanceToCurrentUserInKM} M`}
+                  </div>
+                )}
 								<div className="flex flex-col items-center gap-1 mb-2 w-full">
 									<motion.div>
 										<Image

--- a/components/ui/institution-card.tsx
+++ b/components/ui/institution-card.tsx
@@ -64,8 +64,8 @@ const InstitutionCard = forwardRef<HTMLDivElement, Institution & {isClosest?: bo
 			supportedPayment,
 			category,
 			coords,
-      isClosest,
-      distanceToCurrentUserInMeter,
+			isClosest,
+			distanceToCurrentUserInMeter,
 		},
 		ref,
 	) => {

--- a/components/ui/institution-card.tsx
+++ b/components/ui/institution-card.tsx
@@ -51,7 +51,7 @@ const capitalizeWords = (str: string): string => {
 	});
 };
 
-const InstitutionCard = forwardRef<HTMLDivElement, Institution & {isClosest?: boolean; distanceToCurrentUserInKM?: number}>(
+const InstitutionCard = forwardRef<HTMLDivElement, Institution & {isClosest?: boolean; distanceToCurrentUserInMeter?: number}>(
 	(
 		{
 			id,
@@ -65,7 +65,7 @@ const InstitutionCard = forwardRef<HTMLDivElement, Institution & {isClosest?: bo
 			category,
 			coords,
       isClosest,
-      distanceToCurrentUserInKM,
+      distanceToCurrentUserInMeter,
 		},
 		ref,
 	) => {
@@ -279,7 +279,7 @@ const InstitutionCard = forwardRef<HTMLDivElement, Institution & {isClosest?: bo
 							<CardContent className="flex flex-col items-center gap-2 p-4 h-full">
                 {isClosest && (
                   <div className="absolute top-2 left-2 bg-yellow-500 dark:bg-yellow-400 text-black p-1 px-2 rounded-full text-xs font-semibold">
-                    Closest to you{distanceToCurrentUserInKM && distanceToCurrentUserInKM > 1000 ? ` • ${(distanceToCurrentUserInKM / 1000).toFixed(2)} KM` : ` • ${distanceToCurrentUserInKM} M`}
+                    Closest to you{distanceToCurrentUserInMeter && distanceToCurrentUserInMeter > 1000 ? ` • ${(distanceToCurrentUserInMeter / 1000).toFixed(2)} KM` : ` • ${distanceToCurrentUserInMeter} M`}
                   </div>
                 )}
 								<div className="flex flex-col items-center gap-1 mb-2 w-full">

--- a/components/ui/institution-card.tsx
+++ b/components/ui/institution-card.tsx
@@ -277,11 +277,11 @@ const InstitutionCard = forwardRef<HTMLDivElement, Institution & {isClosest?: bo
 							onClick={() => navigateToItem(category, slugify(name))}
 						>
 							<CardContent className="flex flex-col items-center gap-2 p-4 h-full">
-                {isClosest && (
-                  <div className="absolute top-2 left-2 bg-yellow-500 dark:bg-yellow-400 text-black p-1 px-2 rounded-full text-xs font-semibold">
-                    Closest to you{distanceToCurrentUserInMeter && distanceToCurrentUserInMeter > 1000 ? ` • ${(distanceToCurrentUserInMeter / 1000).toFixed(2)} KM` : ` • ${distanceToCurrentUserInMeter} M`}
-                  </div>
-                )}
+								{isClosest && (
+									<div className="absolute top-2 left-2 bg-yellow-500 dark:bg-yellow-400 text-black p-1 px-2 rounded-full text-xs font-semibold">
+										Closest to you{distanceToCurrentUserInMeter && distanceToCurrentUserInMeter > 1000 ? ` • ${(distanceToCurrentUserInMeter / 1000).toFixed(2)} KM` : ` • ${distanceToCurrentUserInMeter} M`}
+									</div>
+								)}
 								<div className="flex flex-col items-center gap-1 mb-2 w-full">
 									<motion.div>
 										<Image

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"clsx": "^2.1.1",
 		"cmdk": "^1.0.0",
 		"framer-motion": "^11.3.27",
+		"geolib": "^3.3.4",
 		"html2canvas": "^1.4.1",
 		"leaflet": "^1.9.4",
 		"leaflet-defaulticon-compatibility": "^0.1.2",


### PR DESCRIPTION
# RFC: Pin nearest location at top

When I'm using sedekah.je, I found out my most often use case is to donate the current masjid where I am at. It will make my life easier if sedekah.je can detect my location and masjid I'm at so I don't have to manually search everytime.

Some design details: when filtered and the nearest location is not in the filtered list, it won't show up. I think this provides better user experience as user might not intend to use the nearest location when they begin to filter, as they might be looking for specific location.



<img width="520" alt="Screenshot 2024-12-29 at 5 33 25 AM" src="https://github.com/user-attachments/assets/ae513f1a-ce46-4cca-832f-e701f0a433cd" />
<img width="517" alt="Screenshot 2024-12-29 at 5 32 54 AM" src="https://github.com/user-attachments/assets/ea5a431f-e572-4607-bb67-473053993f92" />
<img width="1800" alt="Screenshot 2024-12-29 at 5 33 32 AM" src="https://github.com/user-attachments/assets/5b9a24c1-7090-41e1-a38d-867c964e56db" />
<img width="1800" alt="Screenshot 2024-12-29 at 5 33 39 AM" src="https://github.com/user-attachments/assets/2d24668d-ccef-4401-af0d-eb93a9315c52" />

<img width="1800" alt="Screenshot 2024-12-29 at 5 36 21 AM" src="https://github.com/user-attachments/assets/a376e86b-b211-49f8-8b48-4f5506e3aff9" />
