### PR TITLE
feat: add supportedPayment default value and admin management

### DIFF
--- a/app/(admin)/admin/institutions/approved/[id]/institution-form.tsx
+++ b/app/(admin)/admin/institutions/approved/[id]/institution-form.tsx
@@ -7,6 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import type { Institution } from "@/db/institutions";
 import {
 	categories as CATEGORY_OPTIONS,
+	supportedPayments as PAYMENT_OPTIONS,
 	states as STATE_OPTIONS,
 } from "@/lib/institution-constants";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -61,9 +62,11 @@ const formSchema = z.object({
 	facebook: urlOrEmpty,
 	instagram: urlOrEmpty,
 	website: urlOrEmpty,
+	supportedPayment: z
+		.array(z.enum(PAYMENT_OPTIONS))
+		.min(1, "At least one payment method is required"),
 	qrContent: z.string().optional(),
 });
-
 type FormData = z.infer<typeof formSchema>;
 
 export default function ApprovedInstitutionForm({
@@ -106,6 +109,7 @@ export default function ApprovedInstitutionForm({
 			facebook: institution.socialMedia?.facebook ?? "",
 			instagram: institution.socialMedia?.instagram ?? "",
 			website: institution.socialMedia?.website ?? "",
+			supportedPayment: institution.supportedPayment ?? ["duitnow"],
 			qrContent: institution.qrContent ?? "",
 		},
 	});
@@ -276,6 +280,42 @@ export default function ApprovedInstitutionForm({
 						)}
 					</div>
 
+					<div className="space-y-2">
+						<div className="font-medium">Supported Payment Methods</div>
+						{isEditing ? (
+							<>
+								<div className="flex flex-wrap gap-3">
+									{PAYMENT_OPTIONS.map((payment) => (
+										<label
+											key={payment}
+											className="flex items-center space-x-2"
+										>
+											<input
+												type="checkbox"
+												value={payment}
+												{...register("supportedPayment")}
+												className="rounded border-gray-300"
+											/>
+											<span className="capitalize">{payment}</span>
+										</label>
+									))}
+								</div>
+								{errors.supportedPayment && (
+									<p className="text-sm text-red-500">
+										{errors.supportedPayment.message}
+									</p>
+								)}
+							</>
+						) : (
+							<div className="p-3 bg-muted rounded-md border">
+								{institution.supportedPayment?.length
+									? institution.supportedPayment
+											.map((p) => p.toUpperCase())
+											.join(", ")
+									: "No payment methods specified"}
+							</div>
+						)}
+					</div>
 					{/* QR Content field */}
 					<div className="space-y-2">
 						<label htmlFor="qrContent" className="font-medium">

--- a/app/(admin)/admin/institutions/pending/[id]/institution-review-form.tsx
+++ b/app/(admin)/admin/institutions/pending/[id]/institution-review-form.tsx
@@ -7,6 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import type { Institution } from "@/db/institutions";
 import {
 	categories as CATEGORY_OPTIONS,
+	supportedPayments as PAYMENT_OPTIONS,
 	states as STATE_OPTIONS,
 } from "@/lib/institution-constants";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -77,13 +78,15 @@ const InstitutionReviewForm = forwardRef<ReviewFormHandle, Props>(
 			website: urlOrEmpty,
 			sourceUrl: z.string().optional(),
 			contributorRemarks: z.string().optional(),
+			supportedPayment: z
+				.array(z.enum(PAYMENT_OPTIONS))
+				.min(1, "At least one payment method is required"),
 			qrContent: institution.qrContent
 				? z.string().optional()
 				: z
 						.string()
 						.min(1, "QR content required when automatic extraction fails"),
 		});
-
 		type LocalFormData = z.infer<typeof dynamicSchema>;
 
 		const {
@@ -106,6 +109,7 @@ const InstitutionReviewForm = forwardRef<ReviewFormHandle, Props>(
 				website: institution.socialMedia?.website ?? "",
 				sourceUrl: institution.sourceUrl ?? "",
 				contributorRemarks: institution.contributorRemarks ?? "",
+				supportedPayment: institution.supportedPayment ?? ["duitnow"],
 				qrContent: institution.qrContent ?? "",
 			},
 		});
@@ -260,6 +264,27 @@ const InstitutionReviewForm = forwardRef<ReviewFormHandle, Props>(
 							<Textarea id="address" rows={3} {...register("address")} />
 						</div>
 
+						<div className="space-y-2">
+							<div className="font-medium">Supported Payment Methods</div>
+							<div className="flex flex-wrap gap-3">
+								{PAYMENT_OPTIONS.map((payment) => (
+									<label key={payment} className="flex items-center space-x-2">
+										<input
+											type="checkbox"
+											value={payment}
+											{...register("supportedPayment")}
+											className="rounded border-gray-300"
+										/>
+										<span className="capitalize">{payment}</span>
+									</label>
+								))}
+							</div>
+							{errors.supportedPayment && (
+								<p className="text-sm text-red-500">
+									{errors.supportedPayment.message}
+								</p>
+							)}
+						</div>
 						{/* Manual QR Content field (only shown if missing) */}
 						{!institution.qrContent && (
 							<div className="space-y-2">

--- a/app/(user)/contribute/_lib/submit-institution.ts
+++ b/app/(user)/contribute/_lib/submit-institution.ts
@@ -276,6 +276,7 @@ export async function submitInstitution(
 				qrImage: qrImageUrl,
 				contributorId: contributorId, // Include the contributor ID
 				status: "pending", // Always pending for new submissions
+				supportedPayment: ["duitnow"], // Default to DuitNow for new submissions
 			})
 			.returning({ id: institutions.id });
 


### PR DESCRIPTION
## Summary
- Set supportedPayment to default ['duitnow'] for new user submissions to ensure QR codes render with proper borders
- Add payment method management UI to admin review and edit forms
- Update form validation to require at least one payment method selection

## Test plan
- [x] Test user submission defaults to DuitNow payment method
- [x] Test admin can modify payment methods during review process
- [x] Test admin can edit payment methods for approved institutions
- [x] Test form validation requires at least one payment method
- [x] Test QR codes render with proper payment method borders
- [x] Test accessibility compliance for form labels

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Supported Payment Methods" section to institution forms, allowing selection of one or more payment methods when submitting or editing institution information.
  * Display of selected payment methods is now visible in both admin and review forms.

* **Bug Fixes**
  * Ensured that new institution submissions default to including "duitnow" as a supported payment method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->