### PR TITLE
optimize: add database caching to reduce egress usage

### DIFF
--- a/lib/queries/institutions.ts
+++ b/lib/queries/institutions.ts
@@ -4,78 +4,101 @@ import { db } from "@/db";
 import { institutions, users } from "@/db/schema";
 import { slugify } from "@/lib/utils";
 import { eq } from "drizzle-orm";
+import { unstable_cache } from "next/cache";
+
+const getInstitutionsInternal = unstable_cache(
+	async () => {
+		const results = await db
+			.select({
+				id: institutions.id,
+				name: institutions.name,
+				description: institutions.description,
+				category: institutions.category,
+				state: institutions.state,
+				city: institutions.city,
+				address: institutions.address,
+				qrImage: institutions.qrImage,
+				qrContent: institutions.qrContent,
+				supportedPayment: institutions.supportedPayment,
+				coords: institutions.coords,
+				socialMedia: institutions.socialMedia,
+				status: institutions.status,
+				contributorId: institutions.contributorId,
+				contributorRemarks: institutions.contributorRemarks,
+				sourceUrl: institutions.sourceUrl,
+				reviewedBy: institutions.reviewedBy,
+				reviewedAt: institutions.reviewedAt,
+				adminNotes: institutions.adminNotes,
+				contributorEmail: users.email,
+				isVerified: institutions.isVerified,
+				isActive: institutions.isActive,
+				createdAt: institutions.createdAt,
+				updatedAt: institutions.updatedAt,
+			})
+			.from(institutions)
+			.leftJoin(users, eq(institutions.contributorId, users.id))
+			.where(eq(institutions.status, "approved"))
+			.orderBy(institutions.name);
+
+		return results;
+	},
+	["all-institutions"],
+	{
+		revalidate: 900, // 15 minutes for stable homepage data
+		tags: ["institutions"],
+	},
+);
 
 export async function getInstitutions() {
-	const results = await db
-		.select({
-			id: institutions.id,
-			name: institutions.name,
-			description: institutions.description,
-			category: institutions.category,
-			state: institutions.state,
-			city: institutions.city,
-			address: institutions.address,
-			qrImage: institutions.qrImage,
-			qrContent: institutions.qrContent,
-			supportedPayment: institutions.supportedPayment,
-			coords: institutions.coords,
-			socialMedia: institutions.socialMedia,
-			status: institutions.status,
-			contributorId: institutions.contributorId,
-			contributorRemarks: institutions.contributorRemarks,
-			sourceUrl: institutions.sourceUrl,
-			reviewedBy: institutions.reviewedBy,
-			reviewedAt: institutions.reviewedAt,
-			adminNotes: institutions.adminNotes,
-			contributorEmail: users.email,
-			isVerified: institutions.isVerified,
-			isActive: institutions.isActive,
-			createdAt: institutions.createdAt,
-			updatedAt: institutions.updatedAt,
-		})
-		.from(institutions)
-		.leftJoin(users, eq(institutions.contributorId, users.id))
-		.where(eq(institutions.status, "approved"))
-		.orderBy(institutions.name);
-
-	return results;
+	return getInstitutionsInternal();
 }
 
+const getInstitutionBySlugInternal = unstable_cache(
+	async (slug: string) => {
+		const results = await db
+			.select({
+				id: institutions.id,
+				name: institutions.name,
+				description: institutions.description,
+				category: institutions.category,
+				state: institutions.state,
+				city: institutions.city,
+				address: institutions.address,
+				qrImage: institutions.qrImage,
+				qrContent: institutions.qrContent,
+				supportedPayment: institutions.supportedPayment,
+				coords: institutions.coords,
+				socialMedia: institutions.socialMedia,
+				status: institutions.status,
+				contributorId: institutions.contributorId,
+				contributorRemarks: institutions.contributorRemarks,
+				sourceUrl: institutions.sourceUrl,
+				reviewedBy: institutions.reviewedBy,
+				reviewedAt: institutions.reviewedAt,
+				adminNotes: institutions.adminNotes,
+				contributorEmail: users.email,
+				isVerified: institutions.isVerified,
+				isActive: institutions.isActive,
+				createdAt: institutions.createdAt,
+				updatedAt: institutions.updatedAt,
+			})
+			.from(institutions)
+			.leftJoin(users, eq(institutions.contributorId, users.id))
+			.where(eq(institutions.status, "approved"))
+			.orderBy(institutions.name);
+
+		// Find by slug match using the same slugify function
+		const institution = results.find((inst) => slugify(inst.name) === slug);
+
+		return institution || null;
+	},
+	["institution-by-slug"],
+	{
+		revalidate: 900, // 15 minutes for individual institution pages
+		tags: ["institutions"],
+	},
+);
+
 export async function getInstitutionBySlug(slug: string) {
-	const results = await db
-		.select({
-			id: institutions.id,
-			name: institutions.name,
-			description: institutions.description,
-			category: institutions.category,
-			state: institutions.state,
-			city: institutions.city,
-			address: institutions.address,
-			qrImage: institutions.qrImage,
-			qrContent: institutions.qrContent,
-			supportedPayment: institutions.supportedPayment,
-			coords: institutions.coords,
-			socialMedia: institutions.socialMedia,
-			status: institutions.status,
-			contributorId: institutions.contributorId,
-			contributorRemarks: institutions.contributorRemarks,
-			sourceUrl: institutions.sourceUrl,
-			reviewedBy: institutions.reviewedBy,
-			reviewedAt: institutions.reviewedAt,
-			adminNotes: institutions.adminNotes,
-			contributorEmail: users.email,
-			isVerified: institutions.isVerified,
-			isActive: institutions.isActive,
-			createdAt: institutions.createdAt,
-			updatedAt: institutions.updatedAt,
-		})
-		.from(institutions)
-		.leftJoin(users, eq(institutions.contributorId, users.id))
-		.where(eq(institutions.status, "approved"))
-		.orderBy(institutions.name);
-
-	// Find by slug match using the same slugify function
-	const institution = results.find((inst) => slugify(inst.name) === slug);
-
-	return institution || null;
+	return getInstitutionBySlugInternal(slug);
 }


### PR DESCRIPTION
## Summary
- Add `unstable_cache` to homepage `getInstitutions()` query with 15-minute revalidation
- Add caching to individual institution pages via `getInstitutionBySlug()` 
- Add caching to `/api/institutions` search/filter API with 5-minute revalidation

## Problem
Homepage was hitting database on every visit, causing Supabase egress limit to be exceeded (8.16GB used vs 5GB limit).

## Solution
Implemented Next.js `unstable_cache` with appropriate revalidation times:
- **Homepage data**: 15 minutes (stable data)
- **API search/filter**: 5 minutes (dynamic queries)
- **Individual pages**: 15 minutes (stable data)

All caches use `["institutions"]` tag for proper invalidation when data is updated.

## Test plan
- [x] Verify homepage still loads correctly
- [x] Verify search/filter functionality works
- [x] Verify individual institution pages load
- [x] Run `bun run check` for code quality
- [ ] Monitor Supabase egress usage after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and efficiency of institution-related data fetching by introducing caching for institution queries and filtered search results.
  * Enhanced error handling for institution search requests. 

End-users may notice faster and more consistent loading times when browsing or searching for institutions. No visible changes to the interface or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->