### PR TITLE
fix: add CORS headers to /api/random endpoint

### DIFF
--- a/app/api/random/route.ts
+++ b/app/api/random/route.ts
@@ -10,12 +10,25 @@ export const dynamic = "force-dynamic";
 // and prevents Next.js from caching the response
 export const revalidate = 0;
 
+const corsHeaders = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type",
+};
+
+export async function OPTIONS() {
+	return new NextResponse(null, {
+		status: 204,
+		headers: corsHeaders,
+	});
+}
+
 export async function GET() {
 	try {
 		if (institutions.length === 0) {
 			return NextResponse.json(
 				{ message: "No institutions found" },
-				{ status: 404 },
+				{ status: 404, headers: corsHeaders },
 			);
 		}
 
@@ -27,13 +40,14 @@ export async function GET() {
 				"Cache-Control": "no-cache, no-store, must-revalidate",
 				Pragma: "no-cache",
 				Expires: "0",
+				...corsHeaders,
 			},
 		});
 	} catch (error) {
 		console.error("Error fetching random institution:", error);
 		return NextResponse.json(
 			{ message: "Internal server error" },
-			{ status: 500 },
+			{ status: 500, headers: corsHeaders },
 		);
 	}
 }


### PR DESCRIPTION
Allow cross-origin requests to the random institution API by adding:
- Access-Control-Allow-Origin: * header
- OPTIONS handler for preflight requests
- CORS headers on all response paths (success, 404, error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API endpoints now support cross-origin requests (CORS), enabling seamless integration with web applications from different domains.
  * API properly handles preflight requests and includes appropriate CORS headers in all response scenarios, including successful operations and error cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->