### PR TITLE
fix: add textValue to SelectItem to fix Terengganu filter redirect

### DIFF
--- a/components/filter-state.tsx
+++ b/components/filter-state.tsx
@@ -79,6 +79,7 @@ const FilterState = ({ onStateChange, className, initialState }: Props) => {
 							<SelectItem
 								key={state.value}
 								value={state.value}
+								textValue={state.label}
 								className="flex items-center"
 							>
 								{state.flag ? (


### PR DESCRIPTION
## Summary
Fixes #493 - Terengganu filter was incorrectly redirecting to `?state=Kelantan` instead of `?state=Terengganu`.

## Root Cause
The Radix Select component was having issues resolving the correct value when `SelectItem` contains complex children (Image + nested div/span elements). The `SelectPrimitive.ItemText` wrapper was likely getting confused by the non-text content.

## Fix
Added the `textValue` prop to explicitly tell Radix Select what text value to use for each item. This is the [recommended approach](https://www.radix-ui.com/primitives/docs/components/select#item) when SelectItem contains complex content.

## Testing
- The fix is a one-line change adding `textValue={state.label}` to the SelectItem
- This should resolve the value mismatch without affecting the visual appearance

cc @aerryasmani (issue reporter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter dropdown display to ensure selection labels render correctly in the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->