### PR TITLE
feat: add undo approval functionality for institutions

### DIFF
--- a/app/(admin)/admin/institutions/approved/columns.tsx
+++ b/app/(admin)/admin/institutions/approved/columns.tsx
@@ -2,12 +2,14 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import type { categories, states } from "@/lib/institution-constants";
 import type { ColumnDef } from "@tanstack/react-table";
 import { format } from "date-fns";
 import { ArrowUpDownIcon, EyeIcon } from "lucide-react";
 import Link from "next/link";
 import { AssignContributorDialog } from "./assign-contributor-dialog";
+import { UndoApprovalDialog } from "./undo-approval-dialog";
 
 type ApprovedInstitution = {
 	id: number;
@@ -32,6 +34,28 @@ type User = {
 export const createColumns = (
 	users: User[],
 ): ColumnDef<ApprovedInstitution>[] => [
+	{
+		id: "select",
+		header: ({ table }) => (
+			<Checkbox
+				checked={
+					table.getIsAllPageRowsSelected() ||
+					(table.getIsSomePageRowsSelected() && "indeterminate")
+				}
+				onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+				aria-label="Select all"
+			/>
+		),
+		cell: ({ row }) => (
+			<Checkbox
+				checked={row.getIsSelected()}
+				onCheckedChange={(value) => row.toggleSelected(!!value)}
+				aria-label="Select row"
+			/>
+		),
+		enableSorting: false,
+		enableHiding: false,
+	},
 	{
 		accessorKey: "id",
 		header: "ID",
@@ -129,6 +153,10 @@ export const createColumns = (
 						currentContributorId={row.original.contributorId}
 						currentContributorName={row.original.contributorName}
 						users={users}
+					/>
+					<UndoApprovalDialog
+						institutionId={row.original.id}
+						institutionName={row.original.name}
 					/>
 					<Button variant="ghost" size="sm" asChild>
 						<Link href={`/admin/institutions/approved/${row.original.id}`}>

--- a/app/(admin)/admin/institutions/approved/undo-approval-dialog.tsx
+++ b/app/(admin)/admin/institutions/approved/undo-approval-dialog.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2, Undo2Icon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { undoApproval } from "../_lib/queries";
+
+type Props = {
+	institutionId: number;
+	institutionName: string;
+};
+
+export function UndoApprovalDialog({ institutionId, institutionName }: Props) {
+	const [open, setOpen] = useState(false);
+	const [notes, setNotes] = useState("Duplicate entry");
+	const [isPending, startTransition] = useTransition();
+	const router = useRouter();
+
+	function handleUndo() {
+		setOpen(false);
+		startTransition(async () => {
+			const promise = undoApproval(institutionId, notes);
+			toast.promise(promise, {
+				loading: "Undoing approval...",
+				success: () => {
+					router.refresh();
+					return `${institutionName} approval has been undone.`;
+				},
+				error: (err) => `Failed: ${err.message}`,
+			});
+		});
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={(v) => !isPending && setOpen(v)}>
+			<DialogTrigger asChild>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="text-destructive hover:text-destructive"
+				>
+					<Undo2Icon className="h-4 w-4" />
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Undo Approval</DialogTitle>
+					<DialogDescription>
+						This will reject &ldquo;{institutionName}&rdquo; and remove it from
+						the public directory. This is typically used for duplicate entries.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="py-4">
+					<Textarea
+						value={notes}
+						onChange={(e) => setNotes(e.target.value)}
+						placeholder="Reason for undoing approval (e.g. duplicate of #123)"
+						className="min-h-[100px]"
+					/>
+				</div>
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => setOpen(false)}
+						disabled={isPending}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={handleUndo}
+						disabled={isPending}
+					>
+						{isPending ? (
+							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+						) : null}
+						Undo Approval
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Admins can now undo institution approvals individually or in batches with optional notes/reason
* Added confirmation dialogs to prevent accidental changes
* Multi-row selection enables batch operations on approved institutions
* Batch undo supports up to 100 institutions at once
* Toast notifications provide operation feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->