### PR TITLE
refactor: server-side QR extraction for institution submissions

### DIFF
--- a/app/(admin)/admin/institutions/_lib/upload-qr-replacement.ts
+++ b/app/(admin)/admin/institutions/_lib/upload-qr-replacement.ts
@@ -1,18 +1,12 @@
 "use server";
 
-import {
-	BinaryBitmap,
-	HybridBinarizer,
-	QRCodeReader,
-	RGBLuminanceSource,
-} from "@zxing/library";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
-import sharp from "sharp";
 import { db } from "@/db";
 import { institutions } from "@/db/institutions";
 import { requireAdminSession } from "@/lib/auth-helpers";
 import { r2Storage } from "@/lib/integrations/r2-client";
+import { decodeQrFromBuffer } from "@/lib/qr-decode";
 
 export type UploadQrReplacementResult = {
 	success: boolean;
@@ -45,41 +39,8 @@ export async function uploadQrReplacement(
 		// Upload to R2 storage
 		const qrImageUrl = await r2Storage.uploadFile(buffer, qrImageFile.name);
 
-		// Attempt QR code extraction
-		let qrContent: string | undefined;
-		try {
-			const { data, info } = await sharp(buffer)
-				.ensureAlpha()
-				.raw()
-				.toBuffer({ resolveWithObject: true });
-
-			// Convert RGBA to RGB for @zxing/library
-			const rgbData = new Uint8ClampedArray(info.width * info.height * 3);
-			for (let i = 0, j = 0; i < data.length; i += 4, j += 3) {
-				rgbData[j] = data[i]; // R
-				rgbData[j + 1] = data[i + 1]; // G
-				rgbData[j + 2] = data[i + 2]; // B
-				// Skip alpha channel
-			}
-
-			const luminanceSource = new RGBLuminanceSource(
-				rgbData,
-				info.width,
-				info.height,
-			);
-			const binaryBitmap = new BinaryBitmap(
-				new HybridBinarizer(luminanceSource),
-			);
-			const reader = new QRCodeReader();
-
-			const result = reader.decode(binaryBitmap);
-			if (result) {
-				qrContent = result.getText();
-			}
-		} catch (err) {
-			console.error("QR decode failed:", err);
-			// Don't fail the upload if QR extraction fails
-		}
+		// Attempt QR code extraction using shared server-side utility
+		const qrContent = (await decodeQrFromBuffer(buffer)) ?? undefined;
 
 		return {
 			success: true,

--- a/app/(user)/contribute/_lib/submit-institution.ts
+++ b/app/(user)/contribute/_lib/submit-institution.ts
@@ -180,31 +180,6 @@ export async function submitInstitution(
 		};
 	}
 
-	// --- Duplicate QR content check
-	const qrContentRaw = rawFromForm.qrContent;
-	if (
-		qrContentRaw &&
-		typeof qrContentRaw === "string" &&
-		qrContentRaw.trim() !== ""
-	) {
-		const [existingQr] = await db
-			.select({ id: institutions.id })
-			.from(institutions)
-			.where(eq(institutions.qrContent, qrContentRaw.trim()))
-			.limit(1);
-
-		if (existingQr) {
-			return {
-				status: "error",
-				errors: {
-					general: [
-						"QR code ini telah pun wujud dalam sistem. Sila semak semula.",
-					],
-				},
-			};
-		}
-	}
-
 	const socialMedia = {
 		facebook: formData.get("facebook") || undefined,
 		instagram: formData.get("instagram") || undefined,
@@ -265,6 +240,7 @@ export async function submitInstitution(
 	// --- Handle QR image upload + server-side QR extraction
 	let qrImageUrl: string | undefined;
 	let qrContent: string | null = null;
+	let qrBuffer: Buffer | undefined;
 
 	try {
 		if (qrImageFile && qrImageFile.size > 0) {
@@ -290,46 +266,10 @@ export async function submitInstitution(
 			}
 
 			const arrayBuffer = await qrImageFile.arrayBuffer();
-			const buffer = Buffer.from(arrayBuffer);
-
-			// Upload to R2
-			try {
-				qrImageUrl = await r2Storage.uploadFile(buffer, qrImageFile.name);
-			} catch (uploadError) {
-				console.error("Failed to upload QR image to R2:", uploadError);
-
-				// Log to Telegram with error details
-				try {
-					await logInstitutionSubmissionFailure({
-						error:
-							uploadError instanceof Error
-								? uploadError.message
-								: String(uploadError),
-						institutionName: parsed.data.name,
-						category: parsed.data.category,
-						state: parsed.data.state,
-						city: parsed.data.city,
-						contributorName: user?.name || undefined,
-						contributorEmail: user?.email,
-						errorType: "R2 image upload failure",
-					});
-				} catch (telegramError) {
-					console.error(
-						"Failed to log upload failure to Telegram:",
-						telegramError,
-					);
-				}
-
-				return {
-					status: "error",
-					errors: {
-						qrImage: ["Gagal memuat naik imej QR. Sila cuba lagi."],
-					},
-				};
-			}
+			qrBuffer = Buffer.from(arrayBuffer);
 
 			// Server-side QR extraction (more reliable than browser-side canvas decode)
-			qrContent = await decodeQrFromBuffer(buffer);
+			qrContent = await decodeQrFromBuffer(qrBuffer);
 
 			// Fall back to client-provided value if server extraction fails
 			if (!qrContent) {
@@ -340,26 +280,7 @@ export async function submitInstitution(
 			}
 		}
 	} catch (error) {
-		console.error("Error handling QR image upload:", error);
-
-		// Log to Telegram with error details
-		try {
-			await logInstitutionSubmissionFailure({
-				error: error instanceof Error ? error.message : String(error),
-				institutionName: parsed?.data?.name,
-				category: parsed?.data?.category,
-				state: parsed?.data?.state,
-				city: parsed?.data?.city,
-				contributorName: user?.name || undefined,
-				contributorEmail: user?.email,
-				errorType: "QR image processing failure",
-			});
-		} catch (telegramError) {
-			console.error(
-				"Failed to log QR processing failure to Telegram:",
-				telegramError,
-			);
-		}
+		console.error("Error handling QR image processing:", error);
 
 		return {
 			status: "error",
@@ -369,7 +290,7 @@ export async function submitInstitution(
 		};
 	}
 
-	// --- Server-side duplicate QR check (catches cases where only server decoded)
+	// --- Duplicate QR check (before R2 upload to avoid orphaned objects)
 	if (qrContent) {
 		const [existingQr] = await db
 			.select({ id: institutions.id })
@@ -384,6 +305,44 @@ export async function submitInstitution(
 					general: [
 						"QR code ini telah pun wujud dalam sistem. Sila semak semula.",
 					],
+				},
+			};
+		}
+	}
+
+	// --- Upload to R2 (only after duplicate check passes)
+	if (qrBuffer && qrImageFile) {
+		try {
+			qrImageUrl = await r2Storage.uploadFile(qrBuffer, qrImageFile.name);
+		} catch (uploadError) {
+			console.error("Failed to upload QR image to R2:", uploadError);
+
+			// Log to Telegram with error details
+			try {
+				await logInstitutionSubmissionFailure({
+					error:
+						uploadError instanceof Error
+							? uploadError.message
+							: String(uploadError),
+					institutionName: parsed.data.name,
+					category: parsed.data.category,
+					state: parsed.data.state,
+					city: parsed.data.city,
+					contributorName: user?.name || undefined,
+					contributorEmail: user?.email,
+					errorType: "R2 image upload failure",
+				});
+			} catch (telegramError) {
+				console.error(
+					"Failed to log upload failure to Telegram:",
+					telegramError,
+				);
+			}
+
+			return {
+				status: "error",
+				errors: {
+					qrImage: ["Gagal memuat naik imej QR. Sila cuba lagi."],
 				},
 			};
 		}

--- a/app/(user)/contribute/_lib/submit-institution.ts
+++ b/app/(user)/contribute/_lib/submit-institution.ts
@@ -17,6 +17,7 @@ import {
 	logInstitutionSubmissionFailure,
 	logNewInstitution,
 } from "@/lib/integrations/telegram";
+import { decodeQrFromBuffer } from "@/lib/qr-decode";
 import { isToyyibpay } from "@/lib/qr-utils";
 import { getUserById } from "@/lib/queries/users";
 import { slugify } from "@/lib/utils";
@@ -261,10 +262,9 @@ export async function submitInstitution(
 
 	console.log("Validation passed, proceeding with submission");
 
-	// --- Handle QR image (optional)
+	// --- Handle QR image upload + server-side QR extraction
 	let qrImageUrl: string | undefined;
-	// We get qrContent from the form data now, no more backend processing
-	const qrContent = formData.get("qrContent") as string | null;
+	let qrContent: string | null = null;
 
 	try {
 		if (qrImageFile && qrImageFile.size > 0) {
@@ -327,6 +327,17 @@ export async function submitInstitution(
 					},
 				};
 			}
+
+			// Server-side QR extraction (more reliable than browser-side canvas decode)
+			qrContent = await decodeQrFromBuffer(buffer);
+
+			// Fall back to client-provided value if server extraction fails
+			if (!qrContent) {
+				const clientQrContent = formData.get("qrContent") as string | null;
+				if (clientQrContent?.trim()) {
+					qrContent = clientQrContent.trim();
+				}
+			}
 		}
 	} catch (error) {
 		console.error("Error handling QR image upload:", error);
@@ -356,6 +367,26 @@ export async function submitInstitution(
 				qrImage: ["Berlaku ralat semasa memproses imej QR. Sila cuba lagi."],
 			},
 		};
+	}
+
+	// --- Server-side duplicate QR check (catches cases where only server decoded)
+	if (qrContent) {
+		const [existingQr] = await db
+			.select({ id: institutions.id })
+			.from(institutions)
+			.where(eq(institutions.qrContent, qrContent))
+			.limit(1);
+
+		if (existingQr) {
+			return {
+				status: "error",
+				errors: {
+					general: [
+						"QR code ini telah pun wujud dalam sistem. Sila semak semula.",
+					],
+				},
+			};
+		}
 	}
 
 	// Geocode if coords not provided
@@ -398,6 +429,7 @@ export async function submitInstitution(
 				state: parsed.data.state as (typeof states)[number],
 				coords: coords, // Coords may be updated by geocoding
 				qrImage: qrImageUrl,
+				qrContent: qrContent || null,
 				contributorId: contributorId, // Include the contributor ID
 				status: "pending", // Always pending for new submissions
 				supportedPayment: [isToyyibpay(qrContent) ? "toyyibpay" : "duitnow"],

--- a/lib/qr-decode.ts
+++ b/lib/qr-decode.ts
@@ -43,14 +43,13 @@ export const decodeQrFromBuffer = async (
 			info.width,
 			info.height,
 		);
-		const binaryBitmap = new BinaryBitmap(
-			new HybridBinarizer(luminanceSource),
-		);
+		const binaryBitmap = new BinaryBitmap(new HybridBinarizer(luminanceSource));
 		const reader = new QRCodeReader();
 		const result = reader.decode(binaryBitmap);
 
 		return result?.getText() ?? null;
-	} catch {
+	} catch (err) {
+		console.warn("QR decode failed:", err);
 		return null;
 	}
 };

--- a/lib/qr-decode.ts
+++ b/lib/qr-decode.ts
@@ -1,0 +1,51 @@
+import {
+	BinaryBitmap,
+	HybridBinarizer,
+	QRCodeReader,
+	RGBLuminanceSource,
+} from "@zxing/library";
+import sharp from "sharp";
+
+/**
+ * Decode QR code content from an image buffer using sharp + @zxing/library.
+ *
+ * Uses sharp to convert the image to raw RGBA pixel data, then strips the alpha
+ * channel to produce RGB data compatible with @zxing/library's RGBLuminanceSource.
+ * This approach is more reliable than browser-side canvas decoding because sharp
+ * preserves full image fidelity without browser rendering variance.
+ *
+ * @returns The decoded QR text, or null if decoding fails.
+ */
+export async function decodeQrFromBuffer(
+	buffer: Buffer,
+): Promise<string | null> {
+	try {
+		const { data, info } = await sharp(buffer)
+			.ensureAlpha()
+			.raw()
+			.toBuffer({ resolveWithObject: true });
+
+		// Convert RGBA to RGB for @zxing/library
+		const rgbData = new Uint8ClampedArray(info.width * info.height * 3);
+		for (let i = 0, j = 0; i < data.length; i += 4, j += 3) {
+			rgbData[j] = data[i]; // R
+			rgbData[j + 1] = data[i + 1]; // G
+			rgbData[j + 2] = data[i + 2]; // B
+		}
+
+		const luminanceSource = new RGBLuminanceSource(
+			rgbData,
+			info.width,
+			info.height,
+		);
+		const binaryBitmap = new BinaryBitmap(
+			new HybridBinarizer(luminanceSource),
+		);
+		const reader = new QRCodeReader();
+		const result = reader.decode(binaryBitmap);
+
+		return result?.getText() ?? null;
+	} catch {
+		return null;
+	}
+}

--- a/lib/qr-decode.ts
+++ b/lib/qr-decode.ts
@@ -9,21 +9,26 @@ import sharp from "sharp";
 /**
  * Decode QR code content from an image buffer using sharp + @zxing/library.
  *
- * Uses sharp to convert the image to raw RGBA pixel data, then strips the alpha
- * channel to produce RGB data compatible with @zxing/library's RGBLuminanceSource.
- * This approach is more reliable than browser-side canvas decoding because sharp
- * preserves full image fidelity without browser rendering variance.
+ * Converts the image to sRGB colorspace first (handles grayscale inputs that
+ * would otherwise produce 2-channel GA data), then adds alpha to guarantee
+ * 4-channel RGBA output. Strips alpha to produce RGB data compatible with
+ * @zxing/library's RGBLuminanceSource.
  *
  * @returns The decoded QR text, or null if decoding fails.
  */
-export async function decodeQrFromBuffer(
+export const decodeQrFromBuffer = async (
 	buffer: Buffer,
-): Promise<string | null> {
+): Promise<string | null> => {
 	try {
 		const { data, info } = await sharp(buffer)
+			.toColorspace("srgb")
 			.ensureAlpha()
 			.raw()
 			.toBuffer({ resolveWithObject: true });
+
+		if (info.channels !== 4) {
+			return null;
+		}
 
 		// Convert RGBA to RGB for @zxing/library
 		const rgbData = new Uint8ClampedArray(info.width * info.height * 3);
@@ -48,4 +53,4 @@ export async function decodeQrFromBuffer(
 	} catch {
 		return null;
 	}
-}
+};


### PR DESCRIPTION
Addresses #553

## Summary

Moves QR code decoding from browser-only (canvas + `@zxing/browser`) to server-side (`sharp` + `@zxing/library`) for the institution submission flow. Server-side extraction is more reliable because `sharp` preserves full image fidelity without browser rendering variance or canvas compression artifacts.

### What changed

| File | Change |
|------|--------|
| `lib/qr-decode.ts` | **New** -- shared server-side QR decode utility extracted from admin tool |
| `submit-institution.ts` | Server-side extraction after R2 upload, fallback to client value, duplicate check, persist qrContent in DB |
| `upload-qr-replacement.ts` | Use shared `decodeQrFromBuffer()` instead of inline decode (37 lines -> 1 line) |

### How it works

1. User uploads QR image (client-side compression still runs -- saves bandwidth)
2. Server receives image, uploads to R2
3. **New**: Server decodes QR from the image buffer using `sharp` + `@zxing/library`
4. Falls back to client-provided `qrContent` if server extraction fails (belt-and-suspenders during transition)
5. Runs duplicate QR check with the final extracted content
6. Inserts `qrContent` into DB (previously only used for payment type detection, not persisted)

### What stays the same

- Client-side QR extraction still runs (provides instant feedback to users)
- File upload UI unchanged
- Graceful degradation: submission succeeds even if QR extraction fails on both client and server (admin handles manually)

### Follow-up opportunities

The client-side extraction code (`useQrExtractionLazy`, `QRProcessor`, `QRExtractionFeature`) can be simplified in a follow-up PR now that the server handles extraction. These are shared across multiple features (main form, edit sheet, quest form, admin replacement), so removing them requires updating all consumers:

- `hooks/use-qr-extraction-lazy.ts` -- used by quest form + admin replacement upload
- `app/(user)/contribute/_components/qr-processor.tsx` -- bridge component
- `app/(user)/contribute/_components/qr-extraction-feature.tsx` -- upload UI + extraction feedback
- `@zxing/browser` can be removed from `package.json` once all consumers migrate

## Test plan

- [ ] Submit new institution with clear QR image -- verify `qrContent` is populated in DB
- [ ] Submit with image that has no QR code -- verify submission succeeds with `qrContent = null`
- [ ] Submit duplicate QR -- verify server-side duplicate check catches it
- [ ] Admin QR replacement still works with shared utility
- [ ] ToyyibPay payment detection still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized QR decoding into a shared utility used by institution upload and submission flows.

* **Improvements**
  * Server-side QR decoding with fallback to submitted QR text when needed.
  * Duplicate QR checks now run before uploading images to avoid orphaned uploads.
  * Clearer handling when no QR is found (stored as null) and more consistent error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/khrnchn/sedekah-je/pull/560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
