### PR TITLE
fix(i18n): translate English "submission" to Malay "sumbangan" on leaderboard

### DIFF
--- a/app/(user)/leaderboard/_components/async-leaderboard-stats.tsx
+++ b/app/(user)/leaderboard/_components/async-leaderboard-stats.tsx
@@ -16,7 +16,7 @@ export async function AsyncLeaderboardStats() {
 				<StatCard
 					icon={Star}
 					value={stats.totalContributions}
-					label="Submission QR"
+					label="Sumbangan QR"
 				/>
 				<StatCard
 					icon={Trophy}

--- a/app/(user)/leaderboard/_components/async-top-contributors.tsx
+++ b/app/(user)/leaderboard/_components/async-top-contributors.tsx
@@ -58,7 +58,7 @@ export async function AsyncTopContributors() {
 								{topContributors[1].name}
 							</div>
 							<div className="text-xs md:text-sm text-muted-foreground">
-								{topContributors[1].contributions} submission
+								{topContributors[1].contributions} sumbangan
 							</div>
 						</div>
 						<div className="w-full h-16 md:h-24 bg-slate-300/50 rounded-t-lg flex items-center justify-center mt-2">
@@ -83,7 +83,7 @@ export async function AsyncTopContributors() {
 								{topContributors[0].name}
 							</div>
 							<div className="text-xs md:text-sm text-muted-foreground">
-								{topContributors[0].contributions} submission
+								{topContributors[0].contributions} sumbangan
 							</div>
 						</div>
 						<div className="w-full h-20 md:h-32 bg-yellow-400/50 rounded-t-lg flex items-center justify-center mt-2">
@@ -108,7 +108,7 @@ export async function AsyncTopContributors() {
 								{topContributors[2].name}
 							</div>
 							<div className="text-xs md:text-sm text-muted-foreground">
-								{topContributors[2].contributions} submission
+								{topContributors[2].contributions} sumbangan
 							</div>
 						</div>
 						<div className="w-full h-12 md:h-20 bg-amber-500/50 rounded-t-lg flex items-center justify-center mt-2">
@@ -147,7 +147,7 @@ export async function AsyncTopContributors() {
 										{contributor.name}
 									</div>
 									<div className="text-xs md:text-sm text-muted-foreground">
-										{contributor.contributions} submission
+										{contributor.contributions} sumbangan
 									</div>
 								</div>
 							</div>

--- a/app/(user)/leaderboard/_components/async-your-rank.tsx
+++ b/app/(user)/leaderboard/_components/async-your-rank.tsx
@@ -27,7 +27,7 @@ export async function AsyncYourRank() {
 						Kedudukan Anda
 					</p>
 					<p className="text-lg font-semibold">
-						#{rank.rank} · {rank.contributions} submission
+						#{rank.rank} · {rank.contributions} sumbangan
 					</p>
 				</div>
 			</CardContent>

--- a/app/(user)/leaderboard/page.tsx
+++ b/app/(user)/leaderboard/page.tsx
@@ -10,17 +10,17 @@ import { TopContributorsSkeleton } from "./_components/loading-skeletons";
 export const metadata: Metadata = {
 	title: "Papan Pendahulu",
 	description:
-		"Lihat pengguna paling aktif menghantar QR institusi ke sedekah.je. Papan pendahulu ini berdasarkan jumlah submission QR, bukan jumlah wang yang didermakan.",
+		"Lihat pengguna paling aktif menghantar QR institusi ke sedekah.je. Papan pendahulu ini berdasarkan jumlah sumbangan QR, bukan jumlah wang yang didermakan.",
 	openGraph: {
 		title: "Papan Pendahulu | Sedekah Je",
 		description:
-			"Lihat pengguna paling aktif menghantar QR institusi ke sedekah.je. Papan pendahulu ini berdasarkan jumlah submission QR, bukan jumlah wang yang didermakan.",
+			"Lihat pengguna paling aktif menghantar QR institusi ke sedekah.je. Papan pendahulu ini berdasarkan jumlah sumbangan QR, bukan jumlah wang yang didermakan.",
 		url: "https://sedekah.je/leaderboard",
 	},
 	twitter: {
 		title: "Papan Pendahulu | Sedekah Je",
 		description:
-			"Lihat pengguna paling aktif menghantar QR institusi ke sedekah.je. Papan pendahulu ini berdasarkan jumlah submission QR, bukan jumlah wang yang didermakan.",
+			"Lihat pengguna paling aktif menghantar QR institusi ke sedekah.je. Papan pendahulu ini berdasarkan jumlah sumbangan QR, bukan jumlah wang yang didermakan.",
 	},
 	alternates: {
 		canonical: "https://sedekah.je/leaderboard",
@@ -31,7 +31,7 @@ export default function LeaderboardPage() {
 	return (
 		<UserLayout
 			title="Papan Pendahulu"
-			description="Kedudukan pengguna berdasarkan jumlah submission QR institusi, bukan jumlah sumbangan wang"
+			description="Kedudukan pengguna berdasarkan jumlah sumbangan QR institusi, bukan jumlah sumbangan wang"
 		>
 			<div className="space-y-8">
 				<Suspense fallback={<StatsGrid cols={4} loading={true} />}>


### PR DESCRIPTION
Fixes #538

## Summary

Translates hardcoded English word "submission" to Malay "sumbangan" across the leaderboard page (Papan Pendahulu). The rest of the page is already in Malay -- these were the only English strings.

### Changes (4 files, 10 replacements)

| File | What changed |
|------|-------------|
| `async-top-contributors.tsx` | `{count} submission` -> `{count} sumbangan` (4x: podium + list) |
| `async-your-rank.tsx` | `{count} submission` -> `{count} sumbangan` (1x: rank card) |
| `async-leaderboard-stats.tsx` | `"Submission QR"` -> `"Sumbangan QR"` (1x: stat card label) |
| `page.tsx` | `"submission QR"` -> `"sumbangan QR"` (4x: meta description, OG, Twitter, page description) |

### What was NOT changed

- Code comments and `console.error` messages (`"Form submission error"`) -- these are developer-facing, not user-facing
- Other pages mentioned in #538 (contribute, my-contributions) -- scanned and found no remaining English UI strings

## Test plan

- [ ] Visit `/leaderboard` -- all text should be in Malay
- [ ] Check page source meta tags -- descriptions should use "sumbangan QR"
- [ ] Verify podium (top 3) and list (4th+) both show "sumbangan"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated leaderboard display text and labels to Indonesian terminology across stats cards, contributor rankings, and page metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->