### PR TITLE
feat: add mobile scroll-to-top button on QR listing page

### DIFF
--- a/app/page-client.tsx
+++ b/app/page-client.tsx
@@ -17,6 +17,7 @@ import CollapsibleCustomMap from "@/components/map/custom-map";
 import RawakFooter from "@/components/rawak-footer";
 import Search from "@/components/search";
 import PageSection from "@/components/shared/page-section";
+import { ScrollToTopButton } from "@/components/shared/scroll-to-top-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -744,6 +745,7 @@ export function PageClient({ initialResult, initialSearchParams }: Props) {
 					))}
 				</div>
 			)}
+			<ScrollToTopButton />
 			<RawakFooter />
 		</PageSection>
 	);

--- a/components/shared/scroll-to-top-button.tsx
+++ b/components/shared/scroll-to-top-button.tsx
@@ -34,6 +34,9 @@ export function ScrollToTopButton({
 
 	const scrollToTop = useCallback(() => {
 		window.scrollTo({ top: 0, behavior: "smooth" });
+		if (document.activeElement instanceof HTMLElement) {
+			document.activeElement.blur();
+		}
 	}, []);
 
 	if (!isMobile) return null;
@@ -41,12 +44,12 @@ export function ScrollToTopButton({
 	return (
 		<Button
 			type="button"
-			variant="secondary"
+			variant="outline"
 			size="icon"
 			onClick={scrollToTop}
 			aria-label="Tatal ke atas"
 			className={cn(
-				"fixed right-4 z-40 size-11 rounded-full shadow-lg ring-1 ring-border/60 transition-all duration-300",
+				"fixed right-4 z-40 size-11 rounded-full border-border/24 bg-card/90 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-card/75 transition-all duration-300",
 				visible
 					? "translate-y-0 opacity-100"
 					: "pointer-events-none translate-y-2 opacity-0",

--- a/components/shared/scroll-to-top-button.tsx
+++ b/components/shared/scroll-to-top-button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { ArrowUp } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+
+const SCROLL_THRESHOLD = 400;
+
+type ScrollToTopButtonProps = {
+	className?: string;
+	bottomOffset?: string;
+};
+
+export function ScrollToTopButton({
+	className,
+	bottomOffset = "calc(env(safe-area-inset-bottom) + 5rem)",
+}: ScrollToTopButtonProps) {
+	const isMobile = useIsMobile();
+	const [visible, setVisible] = useState(false);
+
+	useEffect(() => {
+		if (!isMobile) return;
+
+		const onScroll = () => {
+			setVisible(window.scrollY > SCROLL_THRESHOLD);
+		};
+
+		onScroll();
+		window.addEventListener("scroll", onScroll, { passive: true });
+		return () => window.removeEventListener("scroll", onScroll);
+	}, [isMobile]);
+
+	const scrollToTop = useCallback(() => {
+		window.scrollTo({ top: 0, behavior: "smooth" });
+	}, []);
+
+	if (!isMobile) return null;
+
+	return (
+		<Button
+			type="button"
+			variant="secondary"
+			size="icon"
+			onClick={scrollToTop}
+			aria-label="Tatal ke atas"
+			className={cn(
+				"fixed right-4 z-40 size-11 rounded-full shadow-lg ring-1 ring-border/60 transition-all duration-300",
+				visible
+					? "translate-y-0 opacity-100"
+					: "pointer-events-none translate-y-2 opacity-0",
+				className,
+			)}
+			style={{ bottom: bottomOffset }}
+		>
+			<ArrowUp className="size-5" />
+		</Button>
+	);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a floating scroll-to-top button for mobile users browsing the main QR institution grid on the homepage.

## Changes

- New reusable `ScrollToTopButton` component in `components/shared/scroll-to-top-button.tsx`
- Wired into the homepage QR listing (`app/page-client.tsx`)

## Behaviour

- **Mobile only** — uses the existing `useIsMobile` hook (<768px)
- Appears after scrolling ~400px down the page
- Positioned above the fixed `RawakFooter` with safe-area inset support
- Smooth scroll back to top on tap
- Accessible label: "Tatal ke atas"
- Fade/slide transition when showing/hiding

## Why

When browsing the infinite QR grid on mobile, users can scroll quite far before loading more results. A quick way to jump back to the search/filter bar improves navigation without conflicting with the bottom footer actions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c57-3fd6-78b7-bcff-5f1cbb5af4b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c57-3fd6-78b7-bcff-5f1cbb5af4b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating “scroll to top” button on mobile devices.
  * The button appears after scrolling and smoothly returns the page to the top when tapped.
  * It is positioned safely above the bottom edge of the screen and integrated into the main page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->