### PR TITLE
Fix automated pending review navigation scope

### DIFF
--- a/app/(admin)/admin/institutions/_lib/navigation.ts
+++ b/app/(admin)/admin/institutions/_lib/navigation.ts
@@ -1,9 +1,32 @@
 "use server";
 
-import { and, asc, count, desc, eq, gt, lt, ne, or, sql } from "drizzle-orm";
+import {
+	and,
+	asc,
+	count,
+	desc,
+	eq,
+	gt,
+	isNull,
+	like,
+	lt,
+	ne,
+	or,
+	sql,
+} from "drizzle-orm";
 import { db } from "@/db";
 import { institutions } from "@/db/schema";
 import { requireAdminSession } from "@/lib/auth-helpers";
+
+function getPendingScopeCondition(includeAutomated: boolean) {
+	return includeAutomated
+		? sql`true`
+		: or(
+				isNull(institutions.sourceUrl),
+				eq(institutions.sourceUrl, ""),
+				like(institutions.sourceUrl, "http%"),
+			);
+}
 
 /**
  * Get the next pending institution ID in canonical order (createdAt DESC, id DESC).
@@ -11,6 +34,7 @@ import { requireAdminSession } from "@/lib/auth-helpers";
  */
 export async function getNextPendingInstitutionId(
 	currentId: number,
+	includeAutomated: boolean,
 ): Promise<number | null> {
 	await requireAdminSession();
 
@@ -39,6 +63,7 @@ export async function getNextPendingInstitutionId(
 		.where(
 			and(
 				eq(institutions.status, "pending"),
+				getPendingScopeCondition(includeAutomated),
 				ne(institutions.id, currentId),
 				nextCondition,
 			),
@@ -55,6 +80,7 @@ export async function getNextPendingInstitutionId(
  */
 export async function getPrevPendingInstitutionId(
 	currentId: number,
+	includeAutomated: boolean,
 ): Promise<number | null> {
 	await requireAdminSession();
 
@@ -83,6 +109,7 @@ export async function getPrevPendingInstitutionId(
 		.where(
 			and(
 				eq(institutions.status, "pending"),
+				getPendingScopeCondition(includeAutomated),
 				ne(institutions.id, currentId),
 				prevCondition,
 			),
@@ -100,6 +127,7 @@ export async function getPrevPendingInstitutionId(
  */
 export async function getNextToReviewAfterDecision(
 	reviewedId: number,
+	includeAutomated: boolean,
 ): Promise<number | null> {
 	await requireAdminSession();
 
@@ -123,7 +151,13 @@ export async function getNextToReviewAfterDecision(
 	const [prev] = await db
 		.select({ id: institutions.id })
 		.from(institutions)
-		.where(and(eq(institutions.status, "pending"), prevCondition))
+		.where(
+			and(
+				eq(institutions.status, "pending"),
+				getPendingScopeCondition(includeAutomated),
+				prevCondition,
+			),
+		)
 		.orderBy(asc(institutions.createdAt), asc(institutions.id))
 		.limit(1);
 
@@ -135,6 +169,7 @@ export async function getNextToReviewAfterDecision(
  */
 export async function getPendingInstitutionPosition(
 	currentId: number,
+	includeAutomated: boolean,
 ): Promise<{
 	position: number;
 	total: number;
@@ -145,7 +180,11 @@ export async function getPendingInstitutionPosition(
 		.select({ id: institutions.id, createdAt: institutions.createdAt })
 		.from(institutions)
 		.where(
-			and(eq(institutions.id, currentId), eq(institutions.status, "pending")),
+			and(
+				eq(institutions.id, currentId),
+				eq(institutions.status, "pending"),
+				getPendingScopeCondition(includeAutomated),
+			),
 		)
 		.limit(1);
 
@@ -166,6 +205,7 @@ export async function getPendingInstitutionPosition(
 			.where(
 				and(
 					eq(institutions.status, "pending"),
+					getPendingScopeCondition(includeAutomated),
 					ne(institutions.id, currentId),
 					prevCondition,
 				),
@@ -173,7 +213,12 @@ export async function getPendingInstitutionPosition(
 		db
 			.select({ count: count() })
 			.from(institutions)
-			.where(eq(institutions.status, "pending")),
+			.where(
+				and(
+					eq(institutions.status, "pending"),
+					getPendingScopeCondition(includeAutomated),
+				),
+			),
 	]);
 
 	const countBefore = countBeforeResult[0]?.count ?? 0;

--- a/app/(admin)/admin/institutions/_lib/pending-review-scope.test.ts
+++ b/app/(admin)/admin/institutions/_lib/pending-review-scope.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	getPendingListHref,
+	getPendingReviewHref,
+	shouldIncludeAutomated,
+} from "./pending-review-scope";
+
+describe("pending review scope", () => {
+	it("hides automated imports when the URL does not opt in", () => {
+		assert.equal(shouldIncludeAutomated(undefined), false);
+		assert.equal(shouldIncludeAutomated("false"), false);
+		assert.equal(shouldIncludeAutomated(["true"]), false);
+	});
+
+	it("includes automated imports when the URL explicitly opts in", () => {
+		assert.equal(shouldIncludeAutomated("true"), true);
+	});
+
+	it("preserves the default scope without a query parameter", () => {
+		assert.equal(getPendingListHref(false), "/admin/institutions/pending");
+		assert.equal(
+			getPendingReviewHref(42, false),
+			"/admin/institutions/pending/42",
+		);
+	});
+
+	it("carries the include-automated scope through list and detail URLs", () => {
+		assert.equal(
+			getPendingListHref(true),
+			"/admin/institutions/pending?includeAutomated=true",
+		);
+		assert.equal(
+			getPendingReviewHref(42, true),
+			"/admin/institutions/pending/42?includeAutomated=true",
+		);
+	});
+});

--- a/app/(admin)/admin/institutions/_lib/pending-review-scope.ts
+++ b/app/(admin)/admin/institutions/_lib/pending-review-scope.ts
@@ -1,0 +1,21 @@
+export const INCLUDE_AUTOMATED_QUERY = "includeAutomated";
+
+export function shouldIncludeAutomated(
+	value: string | string[] | undefined,
+): boolean {
+	return value === "true";
+}
+
+export function getPendingListHref(includeAutomated: boolean): string {
+	return includeAutomated
+		? `/admin/institutions/pending?${INCLUDE_AUTOMATED_QUERY}=true`
+		: "/admin/institutions/pending";
+}
+
+export function getPendingReviewHref(
+	id: number,
+	includeAutomated: boolean,
+): string {
+	const base = `/admin/institutions/pending/${id}`;
+	return includeAutomated ? `${base}?${INCLUDE_AUTOMATED_QUERY}=true` : base;
+}

--- a/app/(admin)/admin/institutions/pending/[id]/client-section.tsx
+++ b/app/(admin)/admin/institutions/pending/[id]/client-section.tsx
@@ -37,6 +37,7 @@ type Props = {
 	nextId: number | null;
 	position: number;
 	total: number;
+	includeAutomated: boolean;
 };
 
 export default function ClientSection({
@@ -45,6 +46,7 @@ export default function ClientSection({
 	nextId,
 	position,
 	total,
+	includeAutomated,
 }: Props) {
 	const router = useRouter();
 	const formRef = useRef<ReviewFormHandle | null>(null);
@@ -221,6 +223,7 @@ export default function ClientSection({
 					nextId={nextId}
 					position={position}
 					total={total}
+					includeAutomated={includeAutomated}
 				/>
 			</div>
 

--- a/app/(admin)/admin/institutions/pending/[id]/page.tsx
+++ b/app/(admin)/admin/institutions/pending/[id]/page.tsx
@@ -9,15 +9,26 @@ import {
 	getPendingInstitutionPosition,
 	getPrevPendingInstitutionId,
 } from "../../_lib/navigation";
+import {
+	getPendingListHref,
+	shouldIncludeAutomated,
+} from "../../_lib/pending-review-scope";
 import { getPendingInstitutionById } from "../../_lib/queries";
 import ClientSection from "./client-section";
 
 interface Props {
 	params: Promise<{ id: string }>;
+	searchParams: Promise<{ includeAutomated?: string | string[] }>;
 }
 
 export default async function PendingInstitutionReviewPage(props: Props) {
-	const params = await props.params;
+	const [params, searchParams] = await Promise.all([
+		props.params,
+		props.searchParams,
+	]);
+	const includeAutomated = shouldIncludeAutomated(
+		searchParams.includeAutomated,
+	);
 	const idNum = Number(params.id);
 	if (Number.isNaN(idNum)) {
 		notFound();
@@ -25,9 +36,9 @@ export default async function PendingInstitutionReviewPage(props: Props) {
 
 	const [results, prevId, nextId, positionData] = await Promise.all([
 		getPendingInstitutionById(idNum),
-		getPrevPendingInstitutionId(idNum),
-		getNextPendingInstitutionId(idNum),
-		getPendingInstitutionPosition(idNum),
+		getPrevPendingInstitutionId(idNum, includeAutomated),
+		getNextPendingInstitutionId(idNum, includeAutomated),
+		getPendingInstitutionPosition(idNum, includeAutomated),
 	]);
 	const institution = results[0];
 
@@ -45,7 +56,10 @@ export default async function PendingInstitutionReviewPage(props: Props) {
 					breadcrumbs={[
 						{ label: "Dashboard", href: "/admin/dashboard" },
 						{ label: "Institutions", href: "/admin/institutions" },
-						{ label: "Pending", href: "/admin/institutions/pending" },
+						{
+							label: "Pending",
+							href: getPendingListHref(includeAutomated),
+						},
 						{ label: `#${institution.id}` },
 					]}
 				>
@@ -55,6 +69,7 @@ export default async function PendingInstitutionReviewPage(props: Props) {
 						nextId={nextId}
 						position={positionData.position}
 						total={positionData.total}
+						includeAutomated={includeAutomated}
 					/>
 				</AdminLayout>
 			</SidebarInset>

--- a/app/(admin)/admin/institutions/pending/[id]/review-actions.tsx
+++ b/app/(admin)/admin/institutions/pending/[id]/review-actions.tsx
@@ -41,6 +41,10 @@ import {
 	getNextPendingInstitutionId,
 	getNextToReviewAfterDecision,
 } from "../../_lib/navigation";
+import {
+	getPendingListHref,
+	getPendingReviewHref,
+} from "../../_lib/pending-review-scope";
 import type { ReviewFormHandle } from "./institution-review-form";
 
 type Props = {
@@ -52,6 +56,7 @@ type Props = {
 	nextId: number | null;
 	position: number;
 	total: number;
+	includeAutomated: boolean;
 };
 
 export default function ReviewActions({
@@ -63,6 +68,7 @@ export default function ReviewActions({
 	nextId,
 	position,
 	total,
+	includeAutomated,
 }: Props) {
 	const { user } = useAuth();
 	const router = useRouter();
@@ -85,7 +91,10 @@ export default function ReviewActions({
 			let nextPendingId: number | null = null;
 			if (action === "reject") {
 				try {
-					nextPendingId = await getNextPendingInstitutionId(institutionId);
+					nextPendingId = await getNextPendingInstitutionId(
+						institutionId,
+						includeAutomated,
+					);
 				} catch (e) {
 					console.error("[next-navigation]", e);
 				}
@@ -106,19 +115,21 @@ export default function ReviewActions({
 				await promise;
 				if (action === "reject") {
 					if (nextPendingId != null) {
-						router.push(`/admin/institutions/pending/${nextPendingId}`);
+						router.push(getPendingReviewHref(nextPendingId, includeAutomated));
 						return;
 					}
 
-					const nextToReview =
-						await getNextToReviewAfterDecision(institutionId);
+					const nextToReview = await getNextToReviewAfterDecision(
+						institutionId,
+						includeAutomated,
+					);
 					if (nextToReview != null) {
-						router.push(`/admin/institutions/pending/${nextToReview}`);
+						router.push(getPendingReviewHref(nextToReview, includeAutomated));
 						return;
 					}
 				}
 
-				router.push("/admin/institutions/pending");
+				router.push(getPendingListHref(includeAutomated));
 			} catch {
 				// toast.promise displays the action error.
 			}
@@ -147,20 +158,26 @@ export default function ReviewActions({
 		}
 		let nextId: number | null = null;
 		try {
-			nextId = await getNextPendingInstitutionId(institutionId);
+			nextId = await getNextPendingInstitutionId(
+				institutionId,
+				includeAutomated,
+			);
 		} catch (e) {
 			console.error("[next-navigation]", e);
 		}
 		try {
 			await approveInstitution(institutionId, user.id);
 			if (nextId != null) {
-				router.push(`/admin/institutions/pending/${nextId}`);
+				router.push(getPendingReviewHref(nextId, includeAutomated));
 			} else {
-				const nextToReview = await getNextToReviewAfterDecision(institutionId);
+				const nextToReview = await getNextToReviewAfterDecision(
+					institutionId,
+					includeAutomated,
+				);
 				if (nextToReview != null) {
-					router.push(`/admin/institutions/pending/${nextToReview}`);
+					router.push(getPendingReviewHref(nextToReview, includeAutomated));
 				} else {
-					router.push("/admin/institutions/pending");
+					router.push(getPendingListHref(includeAutomated));
 					toast.success("Approved. No more pending institutions");
 				}
 			}
@@ -170,7 +187,7 @@ export default function ReviewActions({
 		} finally {
 			setIsSaving(false);
 		}
-	}, [user?.id, institutionId, router, formRef]);
+	}, [user?.id, institutionId, includeAutomated, router, formRef]);
 
 	useEffect(() => {
 		const down = (e: KeyboardEvent) => {
@@ -201,7 +218,7 @@ export default function ReviewActions({
 					</span>
 					{prevId != null ? (
 						<Button variant="outline" size="icon" asChild>
-							<Link href={`/admin/institutions/pending/${prevId}`}>
+							<Link href={getPendingReviewHref(prevId, includeAutomated)}>
 								<ChevronLeft className="h-4 w-4" />
 							</Link>
 						</Button>
@@ -212,7 +229,7 @@ export default function ReviewActions({
 					)}
 					{nextId != null ? (
 						<Button variant="outline" size="icon" asChild>
-							<Link href={`/admin/institutions/pending/${nextId}`}>
+							<Link href={getPendingReviewHref(nextId, includeAutomated)}>
 								<ChevronRight className="h-4 w-4" />
 							</Link>
 						</Button>

--- a/app/(admin)/admin/institutions/pending/columns.tsx
+++ b/app/(admin)/admin/institutions/pending/columns.tsx
@@ -3,8 +3,8 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDownIcon, MoreHorizontalIcon } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { type ReactNode, useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -30,6 +30,11 @@ import { useAuth } from "@/hooks/use-auth";
 import { formatDateTime } from "@/lib/date-utils";
 import type { categories, states } from "@/lib/institution-constants";
 import { approveInstitution, rejectInstitution } from "../_lib/actions";
+import {
+	getPendingReviewHref,
+	INCLUDE_AUTOMATED_QUERY,
+	shouldIncludeAutomated,
+} from "../_lib/pending-review-scope";
 
 type PendingInstitution = {
 	id: number;
@@ -42,6 +47,30 @@ type PendingInstitution = {
 	sourceUrl: string | null;
 	createdAt: Date;
 };
+
+function PendingInstitutionLink({
+	id,
+	children,
+	className,
+}: {
+	id: number;
+	children: ReactNode;
+	className?: string;
+}) {
+	const searchParams = useSearchParams();
+	const includeAutomated = shouldIncludeAutomated(
+		searchParams.get(INCLUDE_AUTOMATED_QUERY) ?? undefined,
+	);
+
+	return (
+		<Link
+			href={getPendingReviewHref(id, includeAutomated)}
+			className={className}
+		>
+			{children}
+		</Link>
+	);
+}
 
 type ActionDialogProps = {
 	isOpen: boolean;
@@ -166,12 +195,12 @@ export const columns: ColumnDef<PendingInstitution>[] = [
 			);
 		},
 		cell: ({ row }) => (
-			<Link
-				href={`/admin/institutions/pending/${row.getValue("id")}`}
+			<PendingInstitutionLink
+				id={row.getValue("id")}
 				className="font-medium hover:underline"
 			>
 				{row.getValue("name")}
-			</Link>
+			</PendingInstitutionLink>
 		),
 	},
 	{
@@ -322,9 +351,9 @@ export const columns: ColumnDef<PendingInstitution>[] = [
 							</DropdownMenuItem>
 							<DropdownMenuSeparator />
 							<DropdownMenuItem asChild>
-								<Link href={`/admin/institutions/pending/${institution.id}`}>
+								<PendingInstitutionLink id={institution.id}>
 									View details
-								</Link>
+								</PendingInstitutionLink>
 							</DropdownMenuItem>
 							{/* <DropdownMenuItem
 								onClick={() =>

--- a/app/(admin)/admin/institutions/pending/pending-table.tsx
+++ b/app/(admin)/admin/institutions/pending/pending-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ReusableDataTable } from "@/components/reusable-data-table";
 import { Button } from "@/components/ui/button";
@@ -23,12 +23,15 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
-import { useAuth } from "@/hooks/use-auth";
 import { categories, states } from "@/lib/institution-constants";
 import {
 	batchApproveInstitutions,
 	batchRejectInstitutions,
 } from "../_lib/batch-actions";
+import {
+	INCLUDE_AUTOMATED_QUERY,
+	shouldIncludeAutomated,
+} from "../_lib/pending-review-scope";
 import { columns } from "./columns";
 
 export type PendingInstitution = {
@@ -109,7 +112,11 @@ export default function PendingInstitutionsTable({
 	const [selectedIds, setSelectedIds] = useState<number[]>([]);
 	const [category, setCategory] = useState<CategoryFilter>(ALL);
 	const [state, setState] = useState<StateFilter>(ALL);
-	const [hideAutomated, setHideAutomated] = useState(true);
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const hideAutomated = !shouldIncludeAutomated(
+		searchParams.get(INCLUDE_AUTOMATED_QUERY) ?? undefined,
+	);
 	const [actionDialog, setActionDialog] = useState<{
 		isOpen: boolean;
 		type: "approve" | "reject" | null;
@@ -119,7 +126,6 @@ export default function PendingInstitutionsTable({
 	});
 
 	const { toast } = useToast();
-	const { user } = useAuth();
 	const router = useRouter();
 
 	// Refresh data on client navigation if needed
@@ -139,6 +145,19 @@ export default function PendingInstitutionsTable({
 		}
 		return true;
 	});
+
+	const setAutomatedVisibility = (hide: boolean) => {
+		const params = new URLSearchParams(searchParams.toString());
+		if (hide) {
+			params.delete(INCLUDE_AUTOMATED_QUERY);
+		} else {
+			params.set(INCLUDE_AUTOMATED_QUERY, "true");
+		}
+		const query = params.toString();
+		router.replace(query ? `${pathname}?${query}` : pathname, {
+			scroll: false,
+		});
+	};
 
 	const doBulk = async (action: "approve" | "reject", notes: string) => {
 		try {
@@ -219,7 +238,7 @@ export default function PendingInstitutionsTable({
 					<Checkbox
 						id="hide-automated"
 						checked={hideAutomated}
-						onCheckedChange={(value) => setHideAutomated(!!value)}
+						onCheckedChange={(value) => setAutomatedVisibility(!!value)}
 					/>
 					<Label htmlFor="hide-automated" className="whitespace-nowrap">
 						Hide automated imports ({automatedCount})


### PR DESCRIPTION
## Summary

- persist the automated-import filter in the pending review URL
- apply the selected scope to previous, next, position, approve, and reject navigation
- preserve the scope when entering or leaving individual pending reviews

## Verification

- `bun test`
- `bun run type-check`
- targeted Biome check
- database smoke check confirmed filtered navigation candidates exclude automated imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include automated institutions in pending-review workflows.
  * Preserved the automated-institution filter when navigating between lists, details, and review actions.
  * Added URL-based filtering so the selected visibility setting remains active during navigation.
* **Bug Fixes**
  * Updated pending counts, positions, and next/previous navigation to respect the selected institution scope.
* **Tests**
  * Added coverage for automated-institution filtering and URL state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->